### PR TITLE
Change to SceneMediator, other minor updates

### DIFF
--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/ApplicationFacade.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/ApplicationFacade.swift
@@ -22,14 +22,14 @@ class ApplicationFacade: Facade {
     override func initializeController() {
         super.initializeController()
         registerCommand(ApplicationFacade.STARTUP) { StartupCommand() }
-        registerCommand(ApplicationFacade.REGISTER) { RegisterComand() }
+        registerCommand(ApplicationFacade.REGISTER) { RegisterCommand() }
     }
     
     /**
     Singleton Factory Method
     */
     class func getInstance(key: String) -> ApplicationFacade {
-        return Facade.getInstance(key) { k in ApplicationFacade(key: k) } as! ApplicationFacade
+        Facade.getInstance(key) { k in ApplicationFacade(key: k) } as! ApplicationFacade
     }
     
     func registerView(view: UIResponder) {

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/controller/RegisterCommand.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/controller/RegisterCommand.swift
@@ -9,23 +9,23 @@
 import PureMVC
 import UIKit
 
-class RegisterComand: SimpleCommand {
+class RegisterCommand: SimpleCommand {
     
     override func execute(_ notification: INotification) {
-        
-        if let viewComponent = notification.body as? SceneDelegate {
-            facade.registerMediator(SceneMediator(viewComponent: viewComponent))
-        }
-        
-        if let viewComponent = notification.body as? UIViewController {
+
+        switch notification.body {
             
-            if(facade.hasMediator(EmployeeAdminMediator.NAME + viewComponent.title!)) {
-                _ = facade.removeMediator(EmployeeAdminMediator.NAME + viewComponent.title!)
-            }
+            case let viewComponent as SceneDelegate:
+                facade.registerMediator(SceneMediator(viewComponent: viewComponent))
             
-            facade.registerMediator(EmployeeAdminMediator(viewComponent: viewComponent))
+            case let viewComponent as UIViewController:
+                if(facade.hasMediator(EmployeeAdminMediator.NAME + viewComponent.title!)) {
+                    _ = facade.removeMediator(EmployeeAdminMediator.NAME + viewComponent.title!)
+                }
+                facade.registerMediator(EmployeeAdminMediator(viewComponent: viewComponent))
+            
+            default:
+                break
         }
-        
     }
-    
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/RoleProxy.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/RoleProxy.swift
@@ -10,7 +10,7 @@ import PureMVC
 
 class RoleProxy: Proxy {
     
-    override class var NAME: String { return "RoleProxy" }
+    override class var NAME: String { "RoleProxy" }
     
     init() {
         super.init(name: RoleProxy.NAME, data: [RoleVO]())
@@ -58,7 +58,7 @@ class RoleProxy: Proxy {
     }
     
     var roles: [RoleVO] {
-        return data as! [RoleVO]
+        data as! [RoleVO]
     }
     
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/UserProxy.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/UserProxy.swift
@@ -10,7 +10,7 @@ import PureMVC
 
 class UserProxy: Proxy {
     
-    override class var NAME: String { return "UserProxy" }
+    override class var NAME: String { "UserProxy" }
     
     init() {
         super.init(name: UserProxy.NAME, data: [UserVO]())
@@ -49,7 +49,7 @@ class UserProxy: Proxy {
     }
     
     var users: [UserVO] {
-        return data as! [UserVO]
+        data as! [UserVO]
     }
     
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/enum/DeptEnum.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/enum/DeptEnum.swift
@@ -18,7 +18,7 @@ enum DeptEnum: String {
     case HUMAN_RESOURCES = "Human Resources"
     
     static var list: [DeptEnum] {
-        return [
+        [
             ACCT,
             SALES,
             PLANT,
@@ -36,6 +36,6 @@ enum DeptEnum: String {
     }
     
     func equals(_ deptEnum: DeptEnum) -> Bool {
-        return self == deptEnum
+        self == deptEnum
     }
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/enum/RoleEnum.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/enum/RoleEnum.swift
@@ -25,7 +25,7 @@ enum RoleEnum: String {
     case RETURNS = "Returns"
     
     static var list: [RoleEnum] {
-        return [
+        [
             ADMIN,
             ACCT_PAY,
             ACCT_RCV,
@@ -50,6 +50,6 @@ enum RoleEnum: String {
     }
     
     func equals(_ roleEnum: RoleEnum) -> Bool {
-        return self == roleEnum
+        self == roleEnum
     }
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/vo/UserVO.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/model/vo/UserVO.swift
@@ -25,11 +25,11 @@ class UserVO {
     }
     
     var isValid:Bool {
-        return username != "" && first != "" && last != "" && email != "" && password != "" && !department.equals(.NONE_SELECTED)
+        username != "" && first != "" && last != "" && email != "" && password != "" && !department.equals(.NONE_SELECTED)
     }
     
     var givenName: String {
-        return last + ", " + first
+        last + ", " + first
     }
     
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/ApplicationMediator.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/ApplicationMediator.swift
@@ -10,7 +10,7 @@ import PureMVC
 
 class ApplicationMediator: Mediator {
     
-    override class var NAME: String { return "ApplicationMediator" }
+    override class var NAME: String { "ApplicationMediator" }
     
     init(viewComponent: AppDelegate) {
         super.init(name: ApplicationMediator.NAME, viewComponent: viewComponent)

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/EmployeeAdminMediator.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/EmployeeAdminMediator.swift
@@ -14,7 +14,7 @@ class EmployeeAdminMediator: Mediator, UserListDelegate, UserFormDelegate, UserR
     var userProxy: UserProxy?
     var roleProxy: RoleProxy?
     
-    override class var NAME: String { return "EmployeeAdminMediator" }
+    override class var NAME: String { "EmployeeAdminMediator" }
     
     init(viewComponent: UIViewController) {
         super.init(name: EmployeeAdminMediator.NAME + viewComponent.title!, viewComponent: viewComponent)
@@ -37,7 +37,7 @@ class EmployeeAdminMediator: Mediator, UserListDelegate, UserFormDelegate, UserR
     }
     
     func users() -> [UserVO] {
-        return userProxy!.users
+        userProxy!.users
     }
     
     func save(_ userVO: UserVO, roleVO: RoleVO) {
@@ -58,7 +58,7 @@ class EmployeeAdminMediator: Mediator, UserListDelegate, UserFormDelegate, UserR
     }
     
     func getUserRoles(username: String) -> [RoleEnum]? {
-        return roleProxy!.getUserRoles(username)
+        roleProxy!.getUserRoles(username)
     }
     
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/SceneMediator.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/SceneMediator.swift
@@ -1,5 +1,5 @@
 //
-//  ApplicationMediator.swift
+//  SceneMediator.swift
 //  PureMVC SWIFT Demo - EmployeeAdmin
 //
 //  Copyright(c) 2020 Saad Shams <saad.shams@puremvc.org>
@@ -10,10 +10,10 @@ import PureMVC
 
 class SceneMediator: Mediator {
     
-    override class var NAME: String { return "SceneMediator" }
+    override class var NAME: String { "SceneMediator" }
     
     init(viewComponent: SceneDelegate) {
-        super.init(name: ApplicationMediator.NAME, viewComponent: viewComponent)
+        super.init(name: SceneMediator.NAME, viewComponent: viewComponent)
     }
     
 }

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/components/UserForm.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/components/UserForm.swift
@@ -113,9 +113,7 @@ class UserForm: UIViewController, UITableViewDelegate, UITableViewDataSource, UI
     // MARK: - UITableViewDelegate
     
     // UserRoles number of rows
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
-    }
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { 1 }
     
     // UserRoles cells
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -128,17 +126,15 @@ class UserForm: UIViewController, UITableViewDelegate, UITableViewDataSource, UI
     
     // UIPickerViewDelegate
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return DeptEnum.comboList[row].rawValue
+        DeptEnum.comboList[row].rawValue
     }
     
     // UIPickerViewDataSource number of components
-    func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        return 1
-    }
+    func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
     
     // UIPickerViewDataSource number of rows
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return DeptEnum.comboList.count
+        DeptEnum.comboList.count
     }
     
     // resign keyboard

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/components/UserList.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/components/UserList.swift
@@ -69,7 +69,7 @@ class UserList: UITableViewController {
     
     // number of rows
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return userVOs?.count ?? 0
+        userVOs?.count ?? 0
     }
     
     // cell contents

--- a/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/components/UserRole.swift
+++ b/EmployeeAdmin/org/puremvc/swift/demos/uikit/employeeadmin/view/components/UserRole.swift
@@ -74,7 +74,7 @@ class UserRole: UITableViewController {
     
     // number of rows
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return RoleEnum.list.count
+        RoleEnum.list.count
     }
 
 }


### PR DESCRIPTION
Changed SceneMediator to pass its own NAME to super.
Updated comment to reflect correct filename.
Removed the return keyword when it is not required.
Changed RegisterCommand to use a switch.
Corrected spelling of RegisterCommand.